### PR TITLE
Feature get capabilities

### DIFF
--- a/constraints-oapi.yml
+++ b/constraints-oapi.yml
@@ -187,6 +187,20 @@ A proposer can delegate preconfirmations rights by signing a `Delegate` message 
                           "0x987654321fedcba0"   # Example proof payload for commitment type 2
                         ]
                     signature: "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+  /constraints/v0/builder/capabilities:
+    get:
+      operationId: "getCapabilities"
+      tags:
+        - Constraints API
+      summary: "Endpoint to retrieve the constraint capabilities of the Relay"
+      description: "This endpoint returns a list of `constraintTypes` that the Relay supports. The `constraintTypes` are unsigned 64-bit numbers between `0` and `0xffffffffffffffff`."
+      responses:
+        "200":
+          description: "OK"
+          content:
+              application/json:
+                  schema:
+                      $ref: '#/components/schemas/ConstraintCapabilities'
   /constraints/v0/relay/constraints:
     get:
       operationId: "getConstraints"
@@ -348,20 +362,6 @@ A proposer can delegate preconfirmations rights by signing a `Delegate` message 
         "200":
           description: "OK"
           content: {}
-  /constraints/v0/relay/capabilities:
-    get:
-      operationId: "getCapabilities"
-      tags:
-        - Constraints API
-      summary: "Endpoint to retrieve the constraint capabilities of the Relay"
-      description: "This endpoint returns a list of `constraintTypes` that the Relay supports. The `constraintTypes` are unsigned 64-bit numbers between `0` and `0xffffffffffffffff`."
-      responses:
-        "200":
-          description: "OK"
-          content:
-              application/json:
-                  schema:
-                      $ref: '#/components/schemas/ConstraintCapabilities'
 
 components:
   schemas:

--- a/constraints-oapi.yml
+++ b/constraints-oapi.yml
@@ -187,7 +187,6 @@ A proposer can delegate preconfirmations rights by signing a `Delegate` message 
                           "0x987654321fedcba0"   # Example proof payload for commitment type 2
                         ]
                     signature: "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
-
   /constraints/v0/relay/constraints:
     get:
       operationId: "getConstraints"
@@ -264,23 +263,23 @@ A proposer can delegate preconfirmations rights by signing a `Delegate` message 
         - Constraints API
       summary: "Endpoint for Builder to submit a block with proofs of constraint validity to the Relay"
       description: "
-The `VersionedSubmitBlockRequestWithProofs` schema extends `VersionedSubmitBlockRequest` from the original relay specs to include proofs of constraint validity. A Builder can protect their block's content while proving that the block satisfies the constraints by including proofs in the `VersionedSubmitBlockRequestWithProofs` message. To support a wide range of constraint types with different proving requirements, `ConstraintProofs` is left open-ended to allow for future flexibility.
+        The `VersionedSubmitBlockRequestWithProofs` schema extends `VersionedSubmitBlockRequest` from the original relay specs to include proofs of constraint validity. A Builder can protect their block's content while proving that the block satisfies the constraints by including proofs in the `VersionedSubmitBlockRequestWithProofs` message. To support a wide range of constraint types with different proving requirements, `ConstraintProofs` is left open-ended to allow for future flexibility.
 
-    - `commitmentTypes`: list of unsigned 64-bit numbers between `0 `and `0xffffffffffffffff` that represents the type of the proposer commitment (not required to be homogeneous)
+            - `commitmentTypes`: list of unsigned 64-bit numbers between `0 `and `0xffffffffffffffff` that represents the type of the proposer commitment (not required to be homogeneous)
 
-    - `payloads`: list of opaque byte arrays whose interpretation is dependent on the commitmentTypes
+            - `payloads`: list of opaque byte arrays whose interpretation is dependent on the commitmentTypes
 
-    - If `cancellations` is true, the Builder is signaling to opt into bid cancellations
+            - If `cancellations` is true, the Builder is signaling to opt into bid cancellations
 
 
-Requirements:
+        Requirements:
 
- - Each `commitmentType` has a spec that defines how builders can generate `proofs` for their block
+        - Each `commitmentType` has a spec that defines how builders can generate `proofs` for their block
 
- - Each `commitmentType` has a spec that defines how relays and proposers can verify `proofs`
+        - Each `commitmentType` has a spec that defines how relays and proposers can verify `proofs`
 
- - The length of `commitmentTypes` and `payloads` must be the same
-      "
+        - The length of `commitmentTypes` and `payloads` must be the same
+              "
       requestBody:
         required: true
         content:
@@ -349,6 +348,21 @@ Requirements:
         "200":
           description: "OK"
           content: {}
+  /constraints/v0/relay/capabilities:
+    get:
+      operationId: "getCapabilities"
+      tags:
+        - Constraints API
+      summary: "Endpoint to retrieve the constraint capabilities of the Relay"
+      description: "This endpoint returns a list of `constraintTypes` that the Relay supports. The `constraintTypes` are unsigned 64-bit numbers between `0` and `0xffffffffffffffff`."
+      responses:
+        "200":
+          description: "OK"
+          content:
+              application/json:
+                  schema:
+                      $ref: '#/components/schemas/ConstraintCapabilities'
+
 components:
   schemas:
 
@@ -441,6 +455,16 @@ components:
             format: byte
           maxItems: 
             $ref: '#/x-constants/MAX_CONSTRAINTS_PER_SLOT'
+    ConstraintCapabilities:
+      type: object
+      properties:
+        constraintTypes:
+          type: array
+          items:
+            type: integer
+            format: uint64
+      required:
+        - constraintTypes
     Bellatrix.SubmitBlockRequest:
       $ref: "./relay-specs/types/bellatrix/requests.yaml#/Bellatrix/SubmitBlockRequest"
     Capella.SubmitBlockRequest:

--- a/specs/preconf-api.md
+++ b/specs/preconf-api.md
@@ -43,6 +43,7 @@ Also known as the Commitments API
 | `constraints`   | `POST` | [/constraints/v0/builder/constraints](./preconf-api.md#endpoint-constraintsv0builderconstraints)        | Endpoint for Proposer or Gateway to submit a batch of signed constraints to the Relay. |
 | `constraints`   | `POST` | [/constraints/v0/builder/delegate](./preconf-api.md#endpoint-constraintsv0builderdelegate)           | Endpoint for Proposer to delegate preconfirmation rights, or more accurately, constraint submission rights to a Gateway. |
 | `constraints`   | `GET` | [/constraints/v0/builder/header_with_proofs](./preconf-api.md#endpoint-constraintsv0builderheader_with_proofsslotparent_hashpubkey)  | Endpoint for Proposer to request a builder bid with proof of constraint validity. |
+| `constraints`   | `GET` | [/constraints/v0/builder/capabilities](./preconf-api.md#endpoint-constraintsv0buildercapabilities)         | Endpoint to retrieve the constraint capabilities of the Relay. |
 | `constraints`   | `GET` | [/constraints/v0/relay/delegations](./preconf-api.md#endpoint-constraintsv0relaydelegationsslotslot)         | Endpoint to retrieve the signed delegations for the proposer of a given slot, if it exists. |
 | `constraints`   | `GET` | [/constraints/v0/relay/constraints](./preconf-api.md#endpoint-constraintsv0relayconstraintsslotslot)         | Endpoint to retrieve the signed constraints for a given slot. |
 | `constraints`   | `GET` | [/constraints/v0/relay/constraints_stream](./preconf-api.md#endpoint-constraintsv0relayconstraints_streamslotslot)  | Endpoint to retrieve an SSE stream of signed constraints. |
@@ -245,6 +246,34 @@ Endpoint for requesting a builder bid with constraint proofs from a Relay.
         }
     }
     ```
+---
+
+### Endpoint: `/constraints/v0/builder/capabilities`
+
+Endpoint to retrieve the constraint capabilities of the Relay.
+
+- **Method:** `GET`
+- **Parameters:** None
+- **Headers:** None
+- **Response:** `ConstraintCapabilities`
+
+- **Schema**
+    ```python
+    class ConstraintCapabilities(Container):
+        constraintTypes: List[uint64]
+    ```
+---
+
+- **Example Response**
+    ```json
+    {
+        "constraintTypes": [0x00, 0x01]
+    }
+    ```
+
+- **Description**
+
+    The `ConstraintCapabilities` object defines the constraint types that the Relay supports. Gateways and Builders can use this to update their software accordingly.
 ---
 
 ## Builder-facing API
@@ -460,7 +489,6 @@ Endpoint for submitting blocks with proofs of constraint validity to a Relay.
     }
     ```
 ---
-
 
 # Annotated Sequence Diagram
 ```mermaid


### PR DESCRIPTION
Add a new endpoint `getCapabilities`. Since constraintType implementations will be agreed upon outside of the scope of the API, Relays may support different constraintType. This endpoint is to allow for other parties, particularly Builders and Gateways to query the Relay to learn which constraintTypes it supports and which they should also support.

closes #7 